### PR TITLE
✨ Cancel POS orders

### DIFF
--- a/src/lib/server/locks/order-notifications.ts
+++ b/src/lib/server/locks/order-notifications.ts
@@ -233,11 +233,15 @@ async function handleOrderNotification(order: Order): Promise<void> {
 					if (email) {
 						await queueEmail(email, templateKey, vars, {
 							session,
-							...(!!runtimeConfig.sellerIdentity?.contact.email && {
-								bcc: runtimeConfig.sellerIdentity?.contact.email
-							})
+							...(!!runtimeConfig.sellerIdentity?.contact.email &&
+								runtimeConfig.copyOrderEmailsToAdmin && {
+									bcc: runtimeConfig.sellerIdentity?.contact.email
+								})
 						});
-					} else if (runtimeConfig.sellerIdentity?.contact.email) {
+					} else if (
+						runtimeConfig.sellerIdentity?.contact.email &&
+						runtimeConfig.copyOrderEmailsToAdmin
+					) {
 						await queueEmail(runtimeConfig.sellerIdentity?.contact.email, templateKey, vars, {
 							session
 						});

--- a/src/lib/server/orders.ts
+++ b/src/lib/server/orders.ts
@@ -345,12 +345,12 @@ export async function onOrderPaymentFailed(
 			},
 			{
 				$set: {
-					'payments.$.status': 'expired',
+					'payments.$.status': reason,
 					...(order.payments.every(
 						(payment) => payment.status === 'canceled' || payment.status === 'expired'
 					) &&
 						order.status === 'pending' && {
-							status: 'expired'
+							status: reason
 						})
 				}
 			},

--- a/src/lib/server/runtime-config.ts
+++ b/src/lib/server/runtime-config.ts
@@ -122,6 +122,7 @@ const baseConfig = {
 	bity: {
 		clientId: ''
 	},
+	copyOrderEmailsToAdmin: true,
 	usersDarkDefaultTheme: false,
 	employeesDarkDefaultTheme: false,
 	displayPoweredBy: false,

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.server.ts
@@ -31,7 +31,8 @@ export async function load(event) {
 		displayNewsletterCommercialProspection: runtimeConfig.displayNewsletterCommercialProspection,
 		noProBilling: runtimeConfig.noProBilling,
 		cartMaxSeparateItems: runtimeConfig.cartMaxSeparateItems,
-		accountingCurrency: runtimeConfig.accountingCurrency
+		accountingCurrency: runtimeConfig.accountingCurrency,
+		copyOrderEmailsToAdmin: runtimeConfig.copyOrderEmailsToAdmin
 	};
 }
 
@@ -47,6 +48,7 @@ export const actions = {
 				checkoutButtonOnProductPage: z.boolean({ coerce: true }),
 				noProBilling: z.boolean({ coerce: true }),
 				discovery: z.boolean({ coerce: true }),
+				copyOrderEmailsToAdmin: z.boolean({ coerce: true }),
 				subscriptionDuration: z.enum(['month', 'day', 'hour']),
 				mainCurrency: z.enum([CURRENCIES[0], ...CURRENCIES.slice(1).filter((c) => c !== 'SAT')]),
 				secondaryCurrency: z

--- a/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/config/+page.svelte
@@ -390,6 +390,18 @@
 	<label class="checkbox-label">
 		<input
 			type="checkbox"
+			name="copyOrderEmailsToAdmin"
+			class="form-checkbox"
+			checked={data.copyOrderEmailsToAdmin && !!data.sellerIdentity?.contact.email}
+			disabled={!data.sellerIdentity?.contact.email}
+		/>
+		Copy order emails to {data.sellerIdentity?.contact.email || '[no email address]'} (set in
+		<a href="{data.adminPrefix}/identity" class="body-hyperlink underline">identity</a> section)
+	</label>
+
+	<label class="checkbox-label">
+		<input
+			type="checkbox"
 			name="isMaintenance"
 			class="form-checkbox"
 			checked={data.isMaintenance}

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -257,18 +257,16 @@
 								{/if}
 							{/if}
 							{#if data.roleId !== CUSTOMER_ROLE_ID && data.roleId}
-								<div class="grid grid-cols-4 gap-2 mt-2">
-									<form
-										action="/{data.roleId === POS_ROLE_ID ? 'pos' : 'admin'}/order/{data.order
-											._id}/payment/{payment.id}?/cancel"
-										method="post"
-										class="contents"
+								<form
+									action="/{data.roleId === POS_ROLE_ID ? 'pos' : 'admin'}/order/{data.order
+										._id}/payment/{payment.id}?/cancel"
+									method="post"
+									class="contents"
+								>
+									<button type="submit" class="btn btn-red self-start" on:click={confirmCancel}
+										>{t('pos.cta.cancelOrder')}</button
 									>
-										<button type="submit" class="btn btn-red" on:click={confirmCancel}
-											>{t('pos.cta.cancelOrder')}</button
-										>
-									</form>
-								</div>
+								</form>
 							{/if}
 						{/if}
 						{#if (payment.method === 'point-of-sale' || payment.method === 'bank-transfer') && data.roleId !== CUSTOMER_ROLE_ID && data.roleId && payment.status === 'pending'}
@@ -297,6 +295,17 @@
 											placeholder="Detail (card transaction ID, or point-of-sale payment method)"
 										/>
 									{/if}
+
+									<form
+										action="/{data.roleId === POS_ROLE_ID ? 'pos' : 'admin'}/order/{data.order
+											._id}/payment/{payment.id}?/cancel"
+										method="post"
+										class="contents"
+									>
+										<button type="submit" class="btn btn-red" on:click={confirmCancel}
+											>{t('pos.cta.cancelOrder')}</button
+										>
+									</form>
 									<button type="submit" class="btn btn-black">{t('pos.cta.markOrderPaid')}</button>
 								</form>
 							</div>
@@ -428,7 +437,7 @@
 			{/if}
 
 			{#if data.roleId !== CUSTOMER_ROLE_ID && data.roleId}
-				{#if data.order.payments.length > 1 && data.order.status !== 'expired'}
+				{#if data.order.payments.length > 1 && data.order.status !== 'expired' && data.order.status !== 'canceled'}
 					{#if data.order.status === 'paid'}
 						<a class="btn bg-green-600 text-white self-start" href="/order/{data.order._id}/summary"
 							>{t('order.receiptFullyPaid')}</a


### PR DESCRIPTION
Fix #1164 

- Add cancel button on POS orders
- Set status of canceled payment / order to "canceled" rather than "expired"

![image](https://github.com/B2Bitcoin/beBOP/assets/342922/385e55d1-db90-4e17-a015-ddea879a9552)

![image](https://github.com/B2Bitcoin/beBOP/assets/342922/16d4b14b-f2d0-432a-b9f8-9804fb3449de)
