### PR TITLE
✨ Allow optional bank account holder name + address

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -484,6 +484,8 @@
 			"other": "Payment will be confirmed after {count} confirmations.",
 			"zero": "Payment will be confirmed without waiting for confirmations."
 		},
+		"paymentAccountHolder": "Account holder",
+		"paymentAccountHolderAddress": "Address",
 		"paymentAddress": "Payment address",
 		"paymentAmount": "Payment amount",
 		"paymentBic": "BIC",
@@ -503,6 +505,8 @@
 		},
 		"paymentStatusNpub": "Nostr public address for payment status",
 		"receipt": {
+			"accountHolder": "Account holder",
+			"accountHolderAddress": "Address",
 			"alreadyPaidAmount": "Amount previously paid",
 			"bankInfo": "Bank details",
 			"cancelledOrPending": "This call for payment has not been honored and has expired or been canceled",

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -484,6 +484,8 @@
 			"other": "Le paiement sera validé après {count} confirmations.",
 			"zero": "Le paiement sera validé sans attendre les confirmations."
 		},
+		"paymentAccountHolder": "Titulaire du compte",
+		"paymentAccountHolderAddress": "Adresse",
 		"paymentAddress": "Adresse de paiement ",
 		"paymentAmount": "Montant de la transaction (hors frais)",
 		"paymentBic": "BIC",
@@ -503,6 +505,8 @@
 		},
 		"paymentStatusNpub": "Adresse publique Nostr pour le statut de paiement",
 		"receipt": {
+			"accountHolder": "Titulaire",
+			"accountHolderAddress": "Adresse",
 			"alreadyPaidAmount": "Montant déjà payé",
 			"bankInfo": "Coordonnées bancaires",
 			"cancelledOrPending": "Cet appel de paiement n'a pas été honoré et est expiré ou a été annulé",

--- a/src/lib/types/SellerIdentity.ts
+++ b/src/lib/types/SellerIdentity.ts
@@ -20,6 +20,8 @@ export interface SellerIdentity {
 	bank?: {
 		iban: string;
 		bic: string;
+		accountHolder?: string;
+		accountHolderAddress?: string;
 	};
 
 	invoice?: {

--- a/src/routes/(app)/admin[[hash=admin_hash]]/identity/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/identity/+page.server.ts
@@ -53,7 +53,9 @@ export const actions = {
 				bank: z
 					.object({
 						iban: z.string().min(1).max(100).trim(),
-						bic: z.string().min(1).max(100).trim()
+						bic: z.string().min(1).max(100).trim(),
+						accountHolder: z.string().min(1).max(100).trim().optional(),
+						accountHolderAddress: z.string().min(1).max(500).trim().optional()
 					})
 					.optional(),
 				invoice: z

--- a/src/routes/(app)/admin[[hash=admin_hash]]/identity/+page.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/identity/+page.svelte
@@ -8,6 +8,8 @@
 	let issuerInfo = id?.invoice?.issuerInfo;
 	let iban = id?.bank?.iban ?? '';
 	let bic = id?.bank?.bic ?? '';
+	let bankAccountHolder = id?.bank?.accountHolder ?? '';
+	let bankAccountHolderAddress = id?.bank?.accountHolderAddress ?? '';
 
 	const { sortedCountryCodes, countryName } = useI18n();
 </script>
@@ -120,6 +122,28 @@
 	</label>
 
 	<h2 class="text-2xl">Bank account</h2>
+
+	<label class="form-label">
+		Account holder name
+		<input
+			type="text"
+			name="bank.accountHolder"
+			class="form-input max-w-[25rem]"
+			maxlength="100"
+			value={bankAccountHolder}
+		/>
+	</label>
+
+	<label class="form-label">
+		Account holder address
+		<input
+			type="text"
+			name="bank.accountHolderAddress"
+			class="form-input max-w-[25rem]"
+			maxlength="500"
+			value={bankAccountHolderAddress}
+		/>
+	</label>
 
 	<label class="form-label">
 		IBAN

--- a/src/routes/(app)/order/[id]/+page.svelte
+++ b/src/routes/(app)/order/[id]/+page.svelte
@@ -131,6 +131,22 @@
 												<IconSumupWide class="h-12" />
 											</a>
 										{:else if payment.method === 'bank-transfer'}
+											{#if data.sellerIdentity?.bank?.accountHolder}
+												<p>
+													{t('order.paymentAccountHolder')}:
+													<span class="break-words body-secondaryText break-all">
+														{data.sellerIdentity?.bank?.accountHolder}
+													</span>
+												</p>
+											{/if}
+											{#if data.sellerIdentity?.bank?.accountHolderAddress}
+												<p>
+													{t('order.paymentAccountHolderAddress')}:
+													<span class="break-words body-secondaryText break-all">
+														{data.sellerIdentity?.bank?.accountHolderAddress}
+													</span>
+												</p>
+											{/if}
 											<p>
 												{t('order.paymentIban')}:
 												<code class="break-words body-secondaryText break-all">

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
@@ -263,6 +263,20 @@
 	<div class="mt-4 text-right">
 		<h2 class="text-xl">{t('order.receipt.bankInfo')} :</h2>
 		<table class="ml-auto">
+			{#if identity.bank.accountHolder}
+				<tr>
+					<td class="px-2">{t('order.receipt.accountHolder')}</td>
+					<td>
+						{identity.bank.accountHolder}
+					</td>
+				</tr>
+			{/if}
+			{#if identity.bank.accountHolderAddress}
+				<tr>
+					<td class="px-2">{t('order.receipt.accountHolderAddress')}</td>
+					<td>{identity.bank.accountHolderAddress}</td>
+				</tr>
+			{/if}
 			<tr><td class="px-2">IBAN</td><td>{identity.bank.iban}</td></tr>
 			<tr><td class="px-2">BIC</td><td>{identity.bank.bic}</td></tr>
 		</table>


### PR DESCRIPTION
Both optional fields.

A simple text field for address for convenience

Will only appear for receipts on newer orders

![image](https://github.com/B2Bitcoin/beBOP/assets/342922/111b82bd-7ec7-44be-83f7-d95b4632abda)

![image](https://github.com/B2Bitcoin/beBOP/assets/342922/a8fbad60-4a50-4ade-893a-bbd31a5f99a9)
