### PR TITLE
🛂 Handle permissions for specific routes with id params

### DIFF
--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -154,6 +154,7 @@ const indexes: Array<[Collection<any>, IndexSpecification, CreateIndexesOptions?
 	[collections.paidSubscriptions, { cancelledAt: 1, paidUntil: 1, 'notifications.type': 1 }],
 	[collections.paidSubscriptions, { cancelledAt: 1, 'notifications.type': 1, paidUntil: 1 }],
 	[collections.users, { login: 1 }, { unique: true }],
+	[collections.users, { roleId: 1 }], // When deleting a role, check if there are users with that role
 	[
 		collections.users,
 		{ login: 1 },

--- a/src/lib/types/User.ts
+++ b/src/lib/types/User.ts
@@ -24,6 +24,7 @@ export interface User extends Timestamps {
 
 export const SUPER_ADMIN_ROLE_ID = 'super-admin';
 export const POS_ROLE_ID = 'point-of-sale';
+export const TICKET_CHECKER_ROLE_ID = 'ticket-checker';
 export const CUSTOMER_ROLE_ID = 'customer';
 export const MIN_PASSWORD_LENGTH = 8;
 

--- a/src/routes/(app)/admin[[hash=admin_hash]]/+layout.svelte
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/+layout.svelte
@@ -59,13 +59,13 @@
 						</button>
 					</form>
 				</span>
-				{#each adminLinks as adminLink}
+				{#each adminLinks as adminSection}
 					<span class="text-xl hidden sm:inline">
 						<a
-							class={sectionName === adminLink.section ? 'underline' : ''}
-							on:mouseenter={() => (sectionName = adminLink.section)}
-							on:click|preventDefault={() => (sectionName = adminLink.section)}
-							href="#{adminLink.section}">{adminLink.section}</a
+							class={sectionName === adminSection.section ? 'underline' : ''}
+							on:mouseenter={() => (sectionName = adminSection.section)}
+							on:click|preventDefault={() => (sectionName = adminSection.section)}
+							href="#{adminSection.section}">{adminSection.section}</a
 						>
 					</span>
 				{/each}
@@ -82,11 +82,13 @@
 				{/if}
 			</nav>
 			<nav class="flex gap-x-6 items-center">
-				{#each adminLinks.filter((item) => item.section === sectionName) as adminLink}
+				{#each adminLinks.filter((item) => item.section === sectionName) as adminSection}
 					<span class="font-bold text-xl hidden sm:inline">
-						{adminLink.section}
+						{adminSection.section}
 					</span>
-					{#each adminLink.links.filter( (l) => (data.role ? isAllowedOnPage(data.role, l.href, 'read') : true) ) as link}
+					{#each adminSection.links
+						.filter((link) => !link.hidden)
+						.filter((l) => (data.role ? isAllowedOnPage(data.role, l.href, 'read') : true)) as link}
 						<a
 							href={link.href}
 							data-sveltekit-preload-data="off"
@@ -109,11 +111,11 @@
 		transition:slide
 		class="bg-gray-400 text-gray-800 font-light flex flex-col sm:hidden border-x-0 border-b-0 border-opacity-25 border-t-1 border-white px-4 pb-3"
 	>
-		{#each adminLinks as adminLink}
+		{#each adminLinks as adminSection}
 			<span class="font-bold text-xl">
-				{adminLink.section}
+				{adminSection.section}
 			</span>
-			{#each adminLink.links as link}
+			{#each adminSection.links.filter((link) => !link.hidden) as link}
 				<a
 					href={link.href}
 					class={$page.url.pathname.startsWith(link.href) ? 'underline' : ''}

--- a/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/adminLinks.ts
@@ -1,4 +1,17 @@
-export const adminLinks = [
+type AdminLinks = Array<{
+	section: string;
+	links: Array<{
+		href: string;
+		label: string;
+		hidden?: boolean;
+		/**
+		 * Specific endpoints that we want to add explicit roles for.
+		 */
+		endpoints?: string[];
+	}>;
+}>;
+
+export const adminLinks: AdminLinks = [
 	{
 		section: 'Merch',
 		links: [
@@ -9,6 +22,15 @@ export const adminLinks = [
 			{
 				href: '/admin/product',
 				label: 'Products'
+			},
+			{
+				href: '/admin/ticket',
+				label: 'Tickets',
+				hidden: true,
+				/**
+				 * Note: this is also passed in runtimeConfig to create a special role TICKET_CHECKER_ROLE_ID
+				 */
+				endpoints: ['/admin/ticket/:id/burn']
 			},
 			{
 				href: '/admin/picture',

--- a/src/routes/(app)/admin[[hash=admin_hash]]/arm/+page.server.ts
+++ b/src/routes/(app)/admin[[hash=admin_hash]]/arm/+page.server.ts
@@ -4,7 +4,7 @@ import { CUSTOMER_ROLE_ID } from '$lib/types/User';
 export async function load() {
 	const nonCustomers = await collections.users
 		.find({ roleId: { $ne: CUSTOMER_ROLE_ID } })
-		.sort({ createdAt: 1 })
+		.sort({ _id: 1 })
 		.toArray();
 
 	return {


### PR DESCRIPTION
This PR adds the possibility to add specific routes with id params in the ARM

For example `/admin/tickets/:id/burn` (or even `/admin/tickets/*/burn`)

This PR also introduces the `ticket-checker` role, which has access to `/admin/tickets/:id/burn` by default.

Other admins can have `/admin/tickets/*` to be able to unburn tickets.

Note: the burning of tickets is not done in this PR, it will be a follow-up PR