### PR TITLE
Reply for beBOP that required IP on deliveryless order #1368

### DIFF
--- a/src/lib/server/locks/handle-messages.ts
+++ b/src/lib/server/locks/handle-messages.ts
@@ -528,10 +528,7 @@ const commands: Record<
 				return;
 			}
 
-			if (
-				runtimeConfig.collectIPOnDeliverylessOrders &&
-				products.every((product) => !product.shipping)
-			) {
+			if (runtimeConfig.collectIPOnDeliverylessOrders) {
 				await send(
 					`Sorry, this beBOP requires an IP address or shipping address for each order, which is not possible via NostR at the moment`
 				);

--- a/src/lib/server/locks/handle-messages.ts
+++ b/src/lib/server/locks/handle-messages.ts
@@ -533,7 +533,7 @@ const commands: Record<
 				products.every((product) => !product.shipping)
 			) {
 				await send(
-					`Sorry, this beBOP required IP for orders for legal motives, orders through Nostr are disabled ; you can check why on ${ORIGIN}/why-collect-ip`
+					`Sorry, this beBOP requires an IP address or shipping address for each order, which is not possible via NostR at the moment`
 				);
 				return;
 			}

--- a/src/lib/server/locks/handle-messages.ts
+++ b/src/lib/server/locks/handle-messages.ts
@@ -528,6 +528,16 @@ const commands: Record<
 				return;
 			}
 
+			if (
+				runtimeConfig.collectIPOnDeliverylessOrders &&
+				products.every((product) => !product.shipping)
+			) {
+				await send(
+					`Sorry, this beBOP required IP for orders for legal motives, orders through Nostr are disabled ; you can check why on ${ORIGIN}/why-collect-ip`
+				);
+				return;
+			}
+
 			const productById = Object.fromEntries(products.map((p) => [p._id, p]));
 
 			const items = cart.items


### PR DESCRIPTION
Reply "Sorry, this beBOP required IP for orders for legal motives, orders through Nostr are disabled ; you can check why on {bebop-url}/why-collect-ip" for beBOP that required IP on deliveryless order #1368