### PR TITLE
✨ Fix receipts with discounts

### DIFF
--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -479,7 +479,7 @@
 		"paidWith": {
 			"bank-transfer": "Paid with: verified bank transfer",
 			"bitcoin": "Paid with: Bitcoin on-chain payment (1 {paymentCurrency} = {exchangeRate} {mainCurrency} at the time of the order)",
-			"card": "Paid with: bank card via Sum UP",
+			"card": "Paid with: bank card",
 			"free": "Paid Nothing",
 			"lightning": "Paid with: Lightning transaction (1 {paymentCurrency} = {exchangeRate} {mainCurrency} at the time of the order)",
 			"point-of-sale": "Paid in store"
@@ -487,7 +487,7 @@
 		"paidWithSummary": {
 			"bank-transfer": "Paid with: verified bank transfer",
 			"bitcoin": "Paid with: Bitcoin on-chain payment",
-			"card": "Paid with: bank card via Sum UP",
+			"card": "Paid with: bank card",
 			"free": "Paid Nothing",
 			"lightning": "Paid with: Lightning transaction",
 			"point-of-sale": "Paid in store"

--- a/src/lib/translations/en.json
+++ b/src/lib/translations/en.json
@@ -527,6 +527,7 @@
 			"cancelledOrPending": "This call for payment has not been honored and has expired or been canceled",
 			"create": "Download invoice",
 			"createProforma": "Download pre-invoice",
+			"discountExcVat": "Discount Excl. VAT",
 			"endMessage": "We stay at your disposal for any further information. <0></0> Best regards, <1></1> {businessName}",
 			"fullyPaid": {
 				"message": "With this payment, the order {orderNumber} is now fully paid"

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -479,7 +479,7 @@
 		"paidWith": {
 			"bank-transfer": "Pagado con: transferencia bancaria verificada",
 			"bitcoin": "Pagado con: pago en Bitcoin (1 {paymentCurrency} = {exchangeRate} {mainCurrency} al momento del pedido)",
-			"card": "Pagado con: tarjeta bancaria vía Sum UP",
+			"card": "Pagado con: tarjeta bancaria",
 			"free": "No se pagó nada",
 			"lightning": "Pagado con: transacción Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} al momento del pedido)",
 			"point-of-sale": "Pagado en tienda"
@@ -487,7 +487,7 @@
 		"paidWithSummary": {
 			"bank-transfer": "Pagado con: transferencia bancaria verificada",
 			"bitcoin": "Pagado con: transferencia de Bitcoin",
-			"card": "Pagado con: tarjeta bancaria vía Sum UP",
+			"card": "Pagado con: tarjeta bancaria",
 			"free": "No se pagó nada",
 			"lightning": "Pagado con: transacción Lightning",
 			"point-of-sale": "Pagado en tienda"

--- a/src/lib/translations/es-sv.json
+++ b/src/lib/translations/es-sv.json
@@ -527,6 +527,7 @@
 			"cancelledOrPending": "Esta solicitud de pago no ha sido atendida y ha expirado o fué cancelada",
 			"create": "Descargar factura",
 			"createProforma": "Descargar cotización",
+			"discountExcVat": "Descuento sin IVA",
 			"endMessage": "Quedamos a disposición para cualquier información adicional. <0></0> Saludos cordiales, <1></1> {businessName}",
 			"fullyPaid": {
 				"message": "Con este pago, el pedido {orderNumber} está completamente pagado"

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -527,6 +527,7 @@
 			"cancelledOrPending": "Cet appel de paiement n'a pas été honoré et est expiré ou a été annulé",
 			"create": "Télécharger la facture",
 			"createProforma": "Télécharger la pré-facture",
+			"discountExcVat": "Remise HT",
 			"endMessage": "Nous restons à votre disposition pour tout renseignement complémentaire. \n<0></0> Cordialement, <1></1> {businessName}",
 			"fullyPaid": {
 				"message": "Avec ce paiement, la commande {orderNumber} est désormais entièrement payée"

--- a/src/lib/translations/fr.json
+++ b/src/lib/translations/fr.json
@@ -479,7 +479,7 @@
 		"paidWith": {
 			"bank-transfer": "Payé avec : virement bancaire vérifié",
 			"bitcoin": "Payé avec : Paiement Bitcoin on-chain (1 {paymentCurrency} = {exchangeRate} {mainCurrency} au moment de la commande)",
-			"card": "Payé avec : carte bancaire via Sum UP",
+			"card": "Payé avec : carte bancaire",
 			"free": "N'a rien payé",
 			"lightning": "Payé avec : Transaction Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} au moment de la commande)",
 			"point-of-sale": "Payé en magasin"
@@ -487,7 +487,7 @@
 		"paidWithSummary": {
 			"bank-transfer": "Payé avec : virement bancaire vérifié",
 			"bitcoin": "Payé avec : Paiement Bitcoin on-chain",
-			"card": "Payé avec : carte bancaire via Sum UP",
+			"card": "Payé avec : carte bancaire",
 			"free": "N'a rien payé",
 			"lightning": "Payé avec : Transaction Lightning",
 			"point-of-sale": "Payé en magasin"

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -105,6 +105,7 @@
 			"cash": "Contanti",
 			"free": "Niente da pagare (cartello vuoto)",
 			"lightning": "Lightning",
+			"paypal": "PayPal",
 			"point-of-sale": "Punto di vendita",
 			"unavailable": "Nessun metodo di pagamento valido."
 		},
@@ -505,6 +506,7 @@
 		"paymentExpiresAt": "Scadenza del pagamento: <0></0>",
 		"paymentIban": "IBAN a cui spedire il bonifico",
 		"paymentLink": "Clicca qui per pagare con la carta",
+		"paymentLinkGeneric": "Clicca qui per pagare con",
 		"paymentPaidAt": "Pagamento effetuato il {date}",
 		"paymentStatus": {
 			"canceled": "Annullato",

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -527,6 +527,7 @@
 			"cancelledOrPending": "Questa richiesta di pagamento non è stata onorata ed è scaduta o annullata.",
 			"create": "Scarica fattura",
 			"createProforma": "Scarica pre-fattura",
+			"discountExcVat": "Sconto escl. \nI.V.A.",
 			"endMessage": "Rimaniamo a sua disposizione per ogni informazione complementare. <0></0> Cordialmente, <1></1> {businessName}",
 			"fullyPaid": {
 				"message": "Con questo pagamento, l'ordine {orderNumber} è interamente pagato"

--- a/src/lib/translations/it.json
+++ b/src/lib/translations/it.json
@@ -478,7 +478,7 @@
 		"paidWith": {
 			"bank-transfer": "Pagato con: bonifico bancario verificato",
 			"bitcoin": "Pagato con: pagamento Bitcoin sulla blockchain (1 {paymentCurrency} = {exchangeRate} {mainCurrency} al momento dell'ordine",
-			"card": "Pagato con: carta bancaria tramite Sum UP",
+			"card": "Pagato con: carta bancaria",
 			"free": "Nessun pagamento",
 			"lightning": "Pagato con: transazione Lightning (1 {paymentCurrency} = {exchangeRate} {mainCurrency} al momento dell'ordine)",
 			"point-of-sale": "Pagato in magazzino"
@@ -486,7 +486,7 @@
 		"paidWithSummary": {
 			"bank-transfer": "Pagato con: bonifico bancario verificato",
 			"bitcoin": "Pagato con: pagamento Bitcoin sulla blockchain",
-			"card": "Pagato con: carta bancaria tramite Sum UP",
+			"card": "Pagato con: carta bancaria",
 			"free": "Nessun pagamento",
 			"lightning": "Pagato con: transazione Lightning",
 			"point-of-sale": "Pagato in magazzino"

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -527,6 +527,7 @@
 			"cancelledOrPending": "Deze oproep tot betaling is niet gehonoreerd en is verlopen of geannuleerd",
 			"create": "Factuur downloaden",
 			"createProforma": "Voorfactuur downloaden",
+			"discountExcVat": "Korting Excl. \nVAT",
 			"endMessage": "Wij staan ​​tot uw beschikking voor verdere informatie. \n<0></0> Met vriendelijke groet, <1></1> {businessName}",
 			"fullyPaid": {
 				"message": "Met deze betaling is de bestelling {orderNumber} nu volledig betaald"
@@ -541,8 +542,8 @@
 			"quantity": "Aantal",
 			"remainingAmount": "Resterend bedrag te betalen",
 			"summaryTitle": "Samenvatting van de bestelling #{number}",
-			"totalExcVat": "Totaal Excl. \nVAT",
-			"totalInclVat": "Totaal Incl. \nVAT",
+			"totalExcVat": "Totaal Excl. VAT",
+			"totalInclVat": "Totaal Incl. VAT",
 			"totalVat": "Totale BTW",
 			"unitPrice": "Eenheid prijs",
 			"vatFreeReason": "Vrijgesteld van btw: {reason}"

--- a/src/lib/translations/nl.json
+++ b/src/lib/translations/nl.json
@@ -479,7 +479,7 @@
 		"paidWith": {
 			"bank-transfer": "Betaald met: geverifieerde bankoverschrijving",
 			"bitcoin": "Betaald met: Bitcoin on-chain betaling (1 {paymentCurrency} = {exchangeRate} {mainCurrency} op het moment van de bestelling)",
-			"card": "Betaald met: bankkaart via Sum UP",
+			"card": "Betaald met: bankkaart",
 			"free": "Niets betaald",
 			"lightning": "Betaald met: Lightning-transactie (1 {paymentCurrency} = {exchangeRate} {mainCurrency} op het moment van de bestelling)",
 			"point-of-sale": "Betaald in de winkel"
@@ -487,7 +487,7 @@
 		"paidWithSummary": {
 			"bank-transfer": "Betaald met: geverifieerde bankoverschrijving",
 			"bitcoin": "Betaald met: Bitcoin on-chain betaling",
-			"card": "Betaald met: bankkaart via Sum UP",
+			"card": "Betaald met: bankkaart",
 			"free": "Niets betaald",
 			"lightning": "Betaald met: Lightning-transactie",
 			"point-of-sale": "Betaald in de winkel"

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
@@ -71,8 +71,6 @@
 		currency
 	};
 
-	const vatPercentage = totalVat.amount ? totalVat.amount / totalNoTax.amount : 0;
-
 	const discountNoTax = {
 		currency,
 		// Alternative, but not as precise with decimal point:

--- a/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
+++ b/src/routes/(app)/order/[id]/payment/[paymentId]/receipt/+page.svelte
@@ -6,8 +6,6 @@
 	import { invoiceNumberVariables } from '$lib/types/Order.js';
 	import { fixCurrencyRounding } from '$lib/utils/fixCurrencyRounding';
 	import { sum } from '$lib/utils/sum.js';
-	import { sumCurrency } from '$lib/utils/sumCurrency';
-	import { toCurrency } from '$lib/utils/toCurrency';
 	import { marked } from 'marked';
 
 	export let data;


### PR DESCRIPTION
- Reorder to show shipping price before total
- Add "discount" section
- Show correct VAT/HT prices by applying discount proportionally

Much simpler PR than I expected. Not sure if it handles shipping prices correctly (we can open an issue if not) but it should be a nice improvement and fix a lot of things. It works with Multi-VAT orders:

![image](https://github.com/user-attachments/assets/6c1a239e-c53b-4d51-802d-3159f55da010)

## Todo:

In another PR, also fix discount + shipping price if it's an issue
